### PR TITLE
Add clipping functionality to make wireframe geometry look like socce…

### DIFF
--- a/src/components/WireframeBall.tsx
+++ b/src/components/WireframeBall.tsx
@@ -85,6 +85,12 @@ export default function WireframeBall() {
       t, 0, -1,   t, 0, 1,  -t, 0, -1,  -t, 0, 1,
     ];
 
+    // Radius of the source geometry this wireframe is derived from.
+    const BALL_RADIUS = 1.6;
+    // Fraction of the ball radius used to position the clipping planes.
+    const CLIP_PLANE_OFFSET_RATIO = 1.31 / 1.6;
+    const CLIP_PLANE_OFFSET = BALL_RADIUS * CLIP_PLANE_OFFSET_RATIO;
+
     const basePlanes: { normal: THREE.Vector3; constant: number }[] = [];
     for (let i = 0; i < vertices.length; i += 3) {
       const normal = new THREE.Vector3(
@@ -92,7 +98,10 @@ export default function WireframeBall() {
         vertices[i + 1],
         vertices[i + 2],
       ).normalize();
-      basePlanes.push({ normal: normal.clone(), constant: 1.31 });
+      basePlanes.push({
+        normal: normal.clone(),
+        constant: CLIP_PLANE_OFFSET,
+      });
     }
 
     const state = {

--- a/src/components/WireframeBall.tsx
+++ b/src/components/WireframeBall.tsx
@@ -30,7 +30,8 @@ function buildClippedGeometry(
 ): THREE.BufferGeometry {
   const pos = source.getAttribute("position");
   const idx = source.getIndex();
-  const triCount = idx ? idx.count / 3 : pos.count / 3;
+  const vertexCount = idx ? idx.count : pos.count;
+  const triCount = Math.floor(vertexCount / 3);
   const verts: number[] = [];
 
   for (let t = 0; t < triCount; t++) {

--- a/src/components/WireframeBall.tsx
+++ b/src/components/WireframeBall.tsx
@@ -68,9 +68,9 @@ function buildClippedGeometry(
 
   const geo = new THREE.BufferGeometry();
   geo.setAttribute("position", new THREE.Float32BufferAttribute(verts, 3));
-  geo.computeVertexNormals();
   return geo;
 }
+
 
 export default function WireframeBall() {
   let wireframeCanvas!: HTMLCanvasElement;

--- a/src/components/WireframeBall.tsx
+++ b/src/components/WireframeBall.tsx
@@ -13,8 +13,10 @@ function clipPolygon(
     const next = polygon[(i + 1) % polygon.length];
     const dCurr = current.dot(planeNormal) + planeConstant;
     const dNext = next.dot(planeNormal) + planeConstant;
-    if (dCurr >= 0) output.push(current);
-    if (dCurr >= 0 !== dNext >= 0) {
+    const currInside = dCurr >= 0;
+    const nextInside = dNext >= 0;
+    if (currInside) output.push(current);
+    if (currInside !== nextInside) {
       const t = dCurr / (dCurr - dNext);
       output.push(new THREE.Vector3().lerpVectors(current, next, t));
     }

--- a/src/components/WireframeBall.tsx
+++ b/src/components/WireframeBall.tsx
@@ -1,10 +1,97 @@
 import { onMount, onCleanup } from "solid-js";
 import * as THREE from "three";
 
+function clipPolygon(
+  polygon: THREE.Vector3[],
+  planeNormal: THREE.Vector3,
+  planeConstant: number,
+): THREE.Vector3[] {
+  if (polygon.length === 0) return [];
+  const output: THREE.Vector3[] = [];
+  for (let i = 0; i < polygon.length; i++) {
+    const current = polygon[i];
+    const next = polygon[(i + 1) % polygon.length];
+    const dCurr = current.dot(planeNormal) + planeConstant;
+    const dNext = next.dot(planeNormal) + planeConstant;
+    if (dCurr >= 0) output.push(current);
+    if (dCurr >= 0 !== dNext >= 0) {
+      const t = dCurr / (dCurr - dNext);
+      output.push(new THREE.Vector3().lerpVectors(current, next, t));
+    }
+  }
+  return output;
+}
+
+function buildClippedGeometry(
+  source: THREE.BufferGeometry,
+  planes: { normal: THREE.Vector3; constant: number }[],
+): THREE.BufferGeometry {
+  const pos = source.getAttribute("position");
+  const idx = source.getIndex();
+  const triCount = idx ? idx.count / 3 : pos.count / 3;
+  const verts: number[] = [];
+
+  for (let t = 0; t < triCount; t++) {
+    const [i0, i1, i2] = idx
+      ? [idx.getX(t * 3), idx.getX(t * 3 + 1), idx.getX(t * 3 + 2)]
+      : [t * 3, t * 3 + 1, t * 3 + 2];
+
+    let poly = [
+      new THREE.Vector3(pos.getX(i0), pos.getY(i0), pos.getZ(i0)),
+      new THREE.Vector3(pos.getX(i1), pos.getY(i1), pos.getZ(i1)),
+      new THREE.Vector3(pos.getX(i2), pos.getY(i2), pos.getZ(i2)),
+    ];
+
+    for (const p of planes) {
+      poly = clipPolygon(poly, p.normal, p.constant);
+      if (poly.length < 3) break;
+    }
+    if (poly.length < 3) continue;
+
+    for (let i = 1; i < poly.length - 1; i++) {
+      verts.push(
+        poly[0].x,
+        poly[0].y,
+        poly[0].z,
+        poly[i].x,
+        poly[i].y,
+        poly[i].z,
+        poly[i + 1].x,
+        poly[i + 1].y,
+        poly[i + 1].z,
+      );
+    }
+  }
+
+  const geo = new THREE.BufferGeometry();
+  geo.setAttribute("position", new THREE.Float32BufferAttribute(verts, 3));
+  geo.computeVertexNormals();
+  return geo;
+}
+
 export default function WireframeBall() {
   let wireframeCanvas!: HTMLCanvasElement;
 
   onMount(() => {
+    const t = (1 + Math.sqrt(5)) / 2;
+
+    // prettier-ignore
+    const vertices = [
+     -1, t, 0,   1, t, 0,   -1, -t, 0,   1, -t, 0,   
+      0, -1, t,   0, 1, t,   0, -1, -t,   0, 1, -t,
+      t, 0, -1,   t, 0, 1,  -t, 0, -1,  -t, 0, 1,
+    ];
+
+    const basePlanes: { normal: THREE.Vector3; constant: number }[] = [];
+    for (let i = 0; i < vertices.length; i += 3) {
+      const normal = new THREE.Vector3(
+        vertices[i],
+        vertices[i + 1],
+        vertices[i + 2],
+      ).normalize();
+      basePlanes.push({ normal: normal.clone(), constant: 1.31 });
+    }
+
     const state = {
       isDragging: false,
       previousMousePosition: { x: 0, y: 0 },
@@ -17,18 +104,27 @@ export default function WireframeBall() {
     const camera = new THREE.PerspectiveCamera(75, 1, 0.1, 1000);
     camera.position.z = 2.5;
 
-    const renderer = new THREE.WebGLRenderer({ alpha: true, antialias: true, canvas: wireframeCanvas });
+    const renderer = new THREE.WebGLRenderer({
+      alpha: true,
+      antialias: true,
+      canvas: wireframeCanvas,
+    });
     renderer.setSize(200, 200);
 
-    const geometry = new THREE.IcosahedronGeometry(1.37, 0);
-    const material = new THREE.MeshBasicMaterial({
+    const sourceGeo = new THREE.IcosahedronGeometry(1.6, 0);
+    const clippedGeo = buildClippedGeometry(sourceGeo, basePlanes);
+    sourceGeo.dispose();
+
+    const edgesGeo = new THREE.EdgesGeometry(clippedGeo, 1);
+    clippedGeo.dispose();
+
+    const material = new THREE.LineBasicMaterial({
       color: 0xffffff,
-      wireframe: true,
       transparent: true,
       opacity: 0.8,
     });
 
-    const ball = new THREE.Mesh(geometry, material);
+    const ball = new THREE.LineSegments(edgesGeo, material);
     scene.add(ball);
 
     const handlePointerDown = (event: PointerEvent) => {
@@ -71,8 +167,10 @@ export default function WireframeBall() {
         ball.rotation.x += state.velocity.x;
         ball.rotation.y += state.velocity.y;
 
-        state.velocity.x = state.velocity.x * damping + baseVelocity.x * (1 - damping);
-        state.velocity.y = state.velocity.y * damping + baseVelocity.y * (1 - damping);
+        state.velocity.x =
+          state.velocity.x * damping + baseVelocity.x * (1 - damping);
+        state.velocity.y =
+          state.velocity.y * damping + baseVelocity.y * (1 - damping);
       }
 
       renderer.render(scene, camera);
@@ -85,7 +183,7 @@ export default function WireframeBall() {
       window.removeEventListener("pointermove", handlePointerMove);
       window.removeEventListener("pointerup", handlePointerUp);
       cancelAnimationFrame(animationId);
-      geometry.dispose();
+      edgesGeo.dispose();
       material.dispose();
       renderer.dispose();
       scene.remove(ball);

--- a/src/components/WireframeBall.tsx
+++ b/src/components/WireframeBall.tsx
@@ -85,9 +85,7 @@ export default function WireframeBall() {
       t, 0, -1,   t, 0, 1,  -t, 0, -1,  -t, 0, 1,
     ];
 
-    // Radius of the source geometry this wireframe is derived from.
     const BALL_RADIUS = 1.6;
-    // Fraction of the ball radius used to position the clipping planes.
     const CLIP_PLANE_OFFSET_RATIO = 1.31 / 1.6;
     const CLIP_PLANE_OFFSET = BALL_RADIUS * CLIP_PLANE_OFFSET_RATIO;
 


### PR DESCRIPTION
This pull request introduces significant enhancements to the `WireframeBall` component, focusing on custom geometry clipping and rendering improvements. The main changes involve implementing a custom polygon clipping algorithm, generating a clipped icosahedron, and switching to a line-based wireframe rendering for better visual fidelity and performance.

**Geometry clipping and rendering improvements:**

* Added a custom `clipPolygon` function and `buildClippedGeometry` utility to clip the faces of a geometry against multiple planes, enabling the creation of a uniquely "clipped" icosahedron shape. (`src/components/WireframeBall.tsx`)
* Replaced the standard `IcosahedronGeometry` mesh with a custom-clipped geometry, constructed using the new clipping utilities and a set of planes derived from the icosahedron's vertices. (`src/components/WireframeBall.tsx`)
* Switched from rendering a mesh with `MeshBasicMaterial` in wireframe mode to rendering the edges of the clipped geometry using `EdgesGeometry` and `LineSegments` with `LineBasicMaterial`, resulting in a true wireframe appearance. (`src/components/WireframeBall.tsx`)

**Code cleanup and resource management:**

* Updated the cleanup logic to properly dispose of the new `edgesGeo` geometry instead of the old mesh geometry, ensuring no memory leaks. (`src/components/WireframeBall.tsx`)

**Minor code style improvements:**

* Reformatted the velocity update logic for better readability, with no change in behavior. (`src/components/WireframeBall.tsx`)…r ball.